### PR TITLE
[twitter] fixes typo in a DB struct tag

### DIFF
--- a/modules/plugins/twitter.go
+++ b/modules/plugins/twitter.go
@@ -26,7 +26,7 @@ type DB_Twitter_Entry struct {
 
 type DB_Twitter_Tweet struct {
     ID        string `gorethink:"id,omitempty"`
-    CreatedAt string `gorethink:"createdat`
+    CreatedAt string `gorethink:"createdat"`
 }
 
 type Twitter_Safe_Entries struct {


### PR DESCRIPTION
Hi Sebastian,

I found a typo in struct tag of DB_Twitter_Tweet.

Struct tag is optional so this is very minor issue but it can cause problems.
For example, using reflect package and if try to get tag "gorethink", then it will return empty about "CreatedAt" filed.

Regards,
CPark