### PR TITLE
fixes misspells

### DIFF
--- a/helpers/discord.go
+++ b/helpers/discord.go
@@ -583,7 +583,7 @@ func GetUser(userID string) (*discordgo.User, error) {
 	var err error
 	var targetUser discordgo.User
 	cacheCodec := cache.GetRedisCacheCodec()
-	key := fmt.Sprintf("robyul2-discord:api:user:%s", userID) // TOOD: Should we cache this?
+	key := fmt.Sprintf("robyul2-discord:api:user:%s", userID) // TODO: Should we cache this?
 
 	for _, guild := range cache.GetSession().State.Guilds {
 		member, err := GetGuildMemberWithoutApi(guild.ID, userID)

--- a/modules/plugins/youtube/service.go
+++ b/modules/plugins/youtube/service.go
@@ -44,7 +44,7 @@ func (s *service) Stop() {
 	s.stop()
 }
 
-// searchQuerySingle retuns single search result with given type @searchType.
+// searchQuerySingle returns single search result with given type @searchType.
 // returns (nil, nil) when there is no matching results.
 func (s *service) SearchQuerySingle(keywords []string, searchType string) (*youtubeAPI.SearchResult, error) {
 	s.RLock()


### PR DESCRIPTION
I saw these misspells from ```go report``` in the main page of upstream.