### PR TITLE
[drive/randompictures] adds cache for google drive service

### DIFF
--- a/cache/googleDrive.go
+++ b/cache/googleDrive.go
@@ -1,0 +1,36 @@
+package cache
+
+import (
+	"errors"
+	"sync"
+
+	"google.golang.org/api/drive/v3"
+)
+
+var (
+	googleDriveService *drive.Service
+	googleDriveMutex   sync.RWMutex
+)
+
+func SetGoogleDriveService(service *drive.Service) {
+	googleDriveMutex.Lock()
+	defer googleDriveMutex.Unlock()
+
+	googleDriveService = service
+}
+
+func GetGoogleDriveService() *drive.Service {
+	googleDriveMutex.RLock()
+	defer googleDriveMutex.RUnlock()
+
+	if googleDriveService == nil {
+		panic(errors.New("Tried to use google drive service before cache#SetGoogleDriveService() was called"))
+	}
+
+	return googleDriveService
+}
+
+// HasGoogleDrive simple check to confirm drive session was set
+func HasGoogleDrive() bool {
+	return !(googleDriveService == nil)
+}

--- a/modules/plugins/randompictures.go
+++ b/modules/plugins/randompictures.go
@@ -2,7 +2,6 @@ package plugins
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -23,8 +22,6 @@ import (
 	redisCache "github.com/go-redis/cache"
 	rethink "github.com/gorethink/gorethink"
 	"github.com/vmihailenco/msgpack"
-	"golang.org/x/net/context"
-	"golang.org/x/oauth2/google"
 	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/googleapi"
 )
@@ -61,15 +58,10 @@ func (rp *RandomPictures) Commands() []string {
 }
 
 func (rp *RandomPictures) Init(session *discordgo.Session) {
-	// Set up Google Drive Client
-	ctx := context.Background()
-	authJson, err := ioutil.ReadFile(helpers.GetConfig().Path("google.client_credentials_json_location").Data().(string))
-	helpers.Relax(err)
-	config, err := google.JWTConfigFromJSON(authJson, drive.DriveReadonlyScope)
-	helpers.Relax(err)
-	client := config.Client(ctx)
-	driveService, err = drive.New(client)
-	helpers.Relax(err)
+
+	// Get drive service
+	driveService = cache.GetGoogleDriveService()
+
 	// initial random generator
 	rand.Seed(time.Now().Unix())
 


### PR DESCRIPTION
Moved google drive setup from randompictures.go to the launcher and added a cache for it. Drive service will be needed for the biasgame (and possibly other future plugins) so moving it a cache will remove the need to set up the service again elsewhere.